### PR TITLE
Stop tube immediately on button-down in PLAYING

### DIFF
--- a/plasma/player/button.py
+++ b/plasma/player/button.py
@@ -35,11 +35,13 @@ class ButtonWatcher:
                  gpio_pin: int,
                  on_short_press: Callable[[], None],
                  on_long_press: Callable[[], None],
+                 on_press: Callable[[], None] = lambda: None,
                  hold_threshold_s: float = 1.0):
         self._pi = pi
         self._pin = gpio_pin
         self._on_short = on_short_press
         self._on_long = on_long_press
+        self._on_press = on_press
         self._hold_threshold_s = hold_threshold_s
 
         self._lock = threading.Lock()
@@ -91,6 +93,12 @@ class ButtonWatcher:
                 self._hold_threshold_s, self._on_threshold_expired)
             self._timer.daemon = True
             self._timer.start()
+        # Notify outside the lock — the handler may take its own lock or
+        # send OSC, neither of which should serialize with our timer state.
+        try:
+            self._on_press()
+        except Exception:
+            logger.exception("on_press handler raised")
 
     def _handle_release(self) -> None:
         with self._lock:

--- a/plasma/player/mock_button.py
+++ b/plasma/player/mock_button.py
@@ -29,10 +29,12 @@ class MockButtonWatcher:
     def __init__(self,
                  on_short_press: Callable[[], None],
                  on_long_press: Callable[[], None],
-                 on_quit: Callable[[], None]):
+                 on_quit: Callable[[], None],
+                 on_press: Callable[[], None] = lambda: None):
         self._on_short = on_short_press
         self._on_long = on_long_press
         self._on_quit = on_quit
+        self._on_press = on_press
         self._thread = None
         self._stop = threading.Event()
 
@@ -49,23 +51,26 @@ class MockButtonWatcher:
     def stop(self) -> None:
         self._stop.set()
 
+    @staticmethod
+    def _fire(handler: Callable[[], None], name: str) -> None:
+        try:
+            handler()
+        except Exception:
+            logger.exception("%s handler raised", name)
+
     def _run(self) -> None:
         for line in sys.stdin:
             if self._stop.is_set():
                 return
             cmd = line.strip().lower()
             if cmd == '':
-                logger.info("[mock-button] short press")
-                try:
-                    self._on_short()
-                except Exception:
-                    logger.exception("on_short_press handler raised")
+                logger.info("[mock-button] press + short release")
+                self._fire(self._on_press, "on_press")
+                self._fire(self._on_short, "on_short_press")
             elif cmd in ('h', 'hold'):
-                logger.info("[mock-button] long press")
-                try:
-                    self._on_long()
-                except Exception:
-                    logger.exception("on_long_press handler raised")
+                logger.info("[mock-button] press + long hold")
+                self._fire(self._on_press, "on_press")
+                self._fire(self._on_long, "on_long_press")
             elif cmd in ('q', 'quit', 'exit'):
                 logger.info("[mock-button] quit")
                 self._on_quit()

--- a/plasma/player/state_machine.py
+++ b/plasma/player/state_machine.py
@@ -7,13 +7,19 @@
 """Score-player state machine.
 
 Pure logic — no threading, no I/O. The button-watching layer translates
-hardware edges + timers into `short_press()` / `long_press()` calls and the
-runner translates the returned actions into OSC messages.
+hardware edges + timers into `press_down()` / `short_press()` / `long_press()`
+calls and the runner translates the returned actions into OSC messages.
 
 States: IDLE / PLAYING / PAUSED.
 
 Boot safety: the machine always starts in IDLE regardless of the switch's
-initial level. Only edge events (short or long press) cause transitions.
+initial level. Only edge events (press_down / short / long) cause transitions.
+
+Press-down semantics: pressing the button while PLAYING immediately pauses
+the tube (per Jeff's request — without this the tube keeps modulating for
+up to the full hold-threshold while we wait to classify short-vs-long). The
+release-or-timer event that follows decides whether we stay PAUSED (short
+press) or KILL back to IDLE (long press).
 """
 import collections
 import enum
@@ -52,6 +58,10 @@ class PlayerStateMachine:
     def __init__(self):
         self._state = State.IDLE
         self._saved_t = 0.0
+        # True after press_down() pre-paused us from PLAYING. The next
+        # short_press is then a no-op (we already stopped on the press
+        # itself); cleared on any classification.
+        self._pre_paused = False
 
     @property
     def state(self) -> State:
@@ -61,7 +71,23 @@ class PlayerStateMachine:
     def saved_t(self) -> float:
         return self._saved_t
 
+    def press_down(self, playback_t: float) -> List[Action]:
+        """Falling edge of the button. Only PLAYING reacts — we pre-pause
+        the tube so the user gets immediate silence rather than waiting on
+        the short/long classification."""
+        if self._state is State.PLAYING:
+            self._state = State.PAUSED
+            self._saved_t = playback_t
+            self._pre_paused = True
+            return [Action(ActionKind.STOP)]
+        return []
+
     def short_press(self, playback_t: float) -> List[Action]:
+        if self._pre_paused:
+            # press_down already stopped the tube from PLAYING; the release
+            # confirms we stay PAUSED. No further OSC needed.
+            self._pre_paused = False
+            return []
         if self._state is State.IDLE:
             self._state = State.PLAYING
             self._saved_t = 0.0
@@ -76,6 +102,7 @@ class PlayerStateMachine:
         raise AssertionError("unreachable state %r" % self._state)
 
     def long_press(self) -> List[Action]:
+        self._pre_paused = False
         if self._state is State.IDLE:
             # Threshold fired with no playback to kill. Per the design, this
             # is a no-op so a stuck-on switch at boot doesn't auto-kill

--- a/score_player.py
+++ b/score_player.py
@@ -127,6 +127,11 @@ class Player:
                 self._osc.kill()
                 _logger().info("KILL: state -> IDLE, saved_t=0")
 
+    def press_down(self) -> None:
+        with self._lock:
+            actions = self._state_machine.press_down(self._playback_t())
+            self._apply(actions)
+
     def short_press(self) -> None:
         with self._lock:
             actions = self._state_machine.short_press(self._playback_t())
@@ -234,6 +239,7 @@ def main() -> int:
         watcher = MockButtonWatcher(
             on_short_press=player.short_press,
             on_long_press=player.long_press,
+            on_press=player.press_down,
             on_quit=player.request_stop)
         watcher.start()
         pi = None
@@ -248,7 +254,8 @@ def main() -> int:
             pi=pi,
             gpio_pin=button_pin,
             on_short_press=player.short_press,
-            on_long_press=player.long_press)
+            on_long_press=player.long_press,
+            on_press=player.press_down)
         watcher.start()
 
     # SIGINT / SIGTERM both stop the run loop cleanly.

--- a/tests/player/test_state_machine.py
+++ b/tests/player/test_state_machine.py
@@ -70,3 +70,71 @@ def test_short_press_after_kill_starts_from_zero():
     sm.long_press()             # IDLE, saved_t=0
     actions = sm.short_press(0.0)
     assert actions == [Action(ActionKind.START_AT, 0.0)]
+
+
+# --- press_down semantics (Jeff's "immediate stop in PLAYING" feedback) ---
+
+
+def test_press_down_from_idle_is_noop():
+    sm = PlayerStateMachine()
+    actions = sm.press_down(playback_t=0.0)
+    assert sm.state is State.IDLE
+    assert actions == []
+
+
+def test_press_down_from_playing_immediately_pauses():
+    sm = PlayerStateMachine()
+    sm.short_press(0.0)         # IDLE -> PLAYING
+    actions = sm.press_down(playback_t=4.2)
+    assert sm.state is State.PAUSED
+    assert sm.saved_t == 4.2
+    assert actions == [Action(ActionKind.STOP)]
+
+
+def test_press_down_then_short_press_stays_paused_without_extra_osc():
+    """Release before threshold: we're already PAUSED from press_down, and
+    the release must not flip us back to PLAYING."""
+    sm = PlayerStateMachine()
+    sm.short_press(0.0)         # PLAYING
+    sm.press_down(4.2)          # PAUSED at 4.2
+    actions = sm.short_press(playback_t=4.3)
+    assert sm.state is State.PAUSED
+    assert sm.saved_t == 4.2
+    assert actions == []
+
+
+def test_press_down_then_long_press_kills():
+    sm = PlayerStateMachine()
+    sm.short_press(0.0)         # PLAYING
+    sm.press_down(4.2)          # PAUSED at 4.2 (pre-paused flag set)
+    actions = sm.long_press()
+    assert sm.state is State.IDLE
+    assert sm.saved_t == 0.0
+    assert actions == [Action(ActionKind.KILL)]
+
+
+def test_press_down_from_paused_is_noop():
+    """If we're already PAUSED (e.g. a previous short_press), pressing
+    again should not emit a duplicate STOP; the release determines the
+    next state via the existing PAUSED transitions."""
+    sm = PlayerStateMachine()
+    sm.short_press(0.0)
+    sm.short_press(2.0)         # PAUSED at 2.0
+    actions = sm.press_down(playback_t=2.0)
+    assert sm.state is State.PAUSED
+    assert sm.saved_t == 2.0
+    assert actions == []
+    # And the release still resumes from saved_t (no pre_paused interference).
+    resume = sm.short_press(0.0)
+    assert resume == [Action(ActionKind.START_AT, 2.0)]
+
+
+def test_press_down_pre_paused_flag_cleared_after_resume_cycle():
+    """After a press_down + short_press cycle, a *subsequent* short_press
+    from PAUSED must resume normally (the pre_paused flag is one-shot)."""
+    sm = PlayerStateMachine()
+    sm.short_press(0.0)         # PLAYING
+    sm.press_down(4.2)          # PAUSED, _pre_paused=True
+    sm.short_press(4.3)         # stays PAUSED, _pre_paused cleared
+    actions = sm.short_press(0.0)  # PAUSED -> PLAYING normally
+    assert actions == [Action(ActionKind.START_AT, 4.2)]


### PR DESCRIPTION
## Summary

Per Jeff's live-test feedback after #27 landed:

> Long presses also work but have a minor issue: From the Playing state,
> a long press does not pause/stop until the button is released. A button
> down in the Playing state should immediately stop playing, with the
> next state determined by when the button is released.

Before this change, the button watcher started a 1 s threshold timer on
press-down but emitted nothing — the tube kept modulating until either
the release (→ short_press → PAUSED) or the timer (→ long_press → KILL)
resolved. From the user's perspective, holding the button felt unresponsive.

## Change

- `ButtonWatcher` now takes an `on_press` callback, fired on every falling
  edge (outside the timer-state lock).
- New `PlayerStateMachine.press_down(playback_t)` method:
  - From **PLAYING**: transition to **PAUSED**, save `t`, emit `STOP`, and
    flag `_pre_paused = True`.
  - From IDLE / PAUSED: no-op.
- `short_press` honors `_pre_paused`: if set, clear it and stay PAUSED
  (no extra OSC — the tube is already silent). Otherwise unchanged.
- `long_press` clears the flag and proceeds with the existing KILL path.
- `MockButtonWatcher` emits `on_press` before its classification so
  `--mock-button` exercises the same flow.

## Net behavior

| State    | Press-down (immediate)       | Release < 1 s   | Hold ≥ 1 s          |
|----------|------------------------------|-----------------|---------------------|
| IDLE     | _no change_                  | `START` from 0  | _no-op_ (boot-safe) |
| PLAYING  | **PAUSED + `/stop`**         | stay PAUSED     | `KILL` → IDLE       |
| PAUSED   | _no change_                  | resume from t   | `KILL` → IDLE       |

The IDLE and PAUSED rows are intentionally unchanged so the "button feel"
for start and resume stays identical to what Jeff's already verified.

## Test plan

- [x] 6 new state-machine tests covering all `press_down` transitions
  and the `_pre_paused` flag lifecycle (`tests/player/test_state_machine.py`).
- [x] `make test` green on py3.4 + py3.5 (29 tests).
- [ ] Hardware verification on Jeff's Pi — confirm PLAYING + press-down
  silences the tube immediately, and that release < 1 s leaves it
  PAUSED while hold ≥ 1 s returns to IDLE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)